### PR TITLE
Add flag to echo to expand escape characters

### DIFF
--- a/board/raspberrypi/post-build.sh
+++ b/board/raspberrypi/post-build.sh
@@ -12,4 +12,4 @@ fi
 
 # Add USB to fstab
 sed -i '/^\/dev\/sda1/d' ${TARGET_DIR}/etc/fstab
-echo '/dev/sda1\t/mnt\tvfat\trw,sync\t0\t0' >> ${TARGET_DIR}/etc/fstab
+echo -e '/dev/sda1\t/mnt\tvfat\trw,sync\t0\t0' >> ${TARGET_DIR}/etc/fstab


### PR DESCRIPTION
I suppose some variants of echo may do this per default but this it not standard.